### PR TITLE
Fix bundles creating script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ package-lock.json
 build_repos.log
 
 playground/angular-app/src/app/*-native.js
-playground/angular-app/src/app/*-renovated-wrapper.js
 playground/angular-app/src/app/*-wrapper.js
 playground/vue-app/src/components/*-native.js
-playground/vue-app/src/components/*-renovated-wrapper.js
 playground/vue-app/src/components/*-wrapper.js

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 1. If you run it not on Windows, you should install [Git bash](https://gitforwindows.org/). You can see how integrate it with VSCode [here](https://stackoverflow.com/questions/42606837/how-do-i-use-bash-on-windows-from-the-visual-studio-code-integrated-terminal)
 2. Check the current terminal is `bash`
-3. Run `npm i` to install packages
-4. Open `components.json` and add necessary widget
-5. Run `npm run build:repos` for all bundles create. On Unix OS use `npm run build:repos:unix`
+3. Open `components.json` and add necessary widget
+4. Run `npm run build:repos` for all bundles create. On Unix OS use `npm run build:repos:unix`
 
 Check the `bundles` directory after script finish. There should be `NAME-basic.js` and `NAME-renovated.js` bundles in jquery directory and 3 bundles for each another approach: `NAME-native.js`, `NAME-wrapper.js` and `NAME-renovated-wrapper.js`.
 

--- a/build.sh
+++ b/build.sh
@@ -14,9 +14,13 @@ clone_and_build_repo()
     [ -f "./strategy/vue2/package-lock.json" ] && rm ./strategy/vue2/package-lock.json
     git pull && log 2 SUCCESS 'git pull' || log 2 ERROR 'git pull'
 
-    $SUDO npm i ../devextreme/artifacts/npm/devextreme$3 &&
+    $SUDO npm i ../devextreme/artifacts/npm/devextreme-renovation &&
         log 3 SUCCESS 'update path to devextreme in '$REPO ||
         log 3 ERROR 'update path to devextreme in '$REPO
+
+    $SUDO npm i devextreme-internal-tools@latest &&
+        log 3 SUCCESS 'update internal tools in '$REPO ||
+        log 3 ERROR 'update internal tools in '$REPO
 
     $SUDO npm i && log 3 SUCCESS 'install packages' || log 3 ERROR 'install packages'
 
@@ -88,6 +92,10 @@ fi
 # Remember log file absolute path
 LOG_FILE=$(pwd)/build_repos.log
 
+# Clear node_modules to aboid problems with Angular building
+[ -f "./node_modules" ] && rm -r node_modules &&
+    log 1 SUCCESS 'node_modules removed'
+
 # Clear bundles dir
 [ -d "./bundles" ] && $SUDO rm -r bundles
 
@@ -117,6 +125,9 @@ log 1 END 'process vue repo'
 log 1 START 'process angular repo'
 process_repo angular
 log 1 END 'process angular repo'
+
+npm i &&
+    log 1 SUCCESS 'packages installed'
 
 # Create directories for bundles
 echo '' >> $LOG_FILE

--- a/playground/angular-app/angular.json
+++ b/playground/angular-app/angular.json
@@ -24,8 +24,8 @@
               "src/assets"
             ],
             "styles": [
-              "../../devextreme/artifacts/npm/devextreme/dist/css/dx.common.css",
-              "../../devextreme/artifacts/npm/devextreme/dist/css/dx.light.css",
+              "../../devextreme/artifacts/npm/devextreme-renovation/dist/css/dx.common.css",
+              "../../devextreme/artifacts/npm/devextreme-renovation/dist/css/dx.light.css",
               "src/styles.css"
             ],
             "scripts": []


### PR DESCRIPTION
1. Fixed path to devextreme in repos dependencies update script (`build:r` task doesn't create `artifacts/npm/devextreme` anymore)
2. Added `devextreme-internal-tools` update to `latest` version because of repos tools desynchronization
3. Added `node_modules` dir drop on script start and packages installing after repos build to avoid problems with angular build
4. Fixed path to dx styles in `angular-app`